### PR TITLE
Add tests for decoding Int64

### DIFF
--- a/JSON.xcodeproj/project.pbxproj
+++ b/JSON.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		013B78AB1FDB3231001246E1 /* IntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013B78AA1FDB3231001246E1 /* IntTests.swift */; };
+		013B78AC1FDB3231001246E1 /* IntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013B78AA1FDB3231001246E1 /* IntTests.swift */; };
+		013B78AD1FDB3231001246E1 /* IntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 013B78AA1FDB3231001246E1 /* IntTests.swift */; };
 		213822041D94723700C1FEEB /* JSON.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 213821FA1D94723700C1FEEB /* JSON.framework */; };
 		2138221C1D94725B00C1FEEB /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 213822151D94725B00C1FEEB /* JSON.swift */; };
 		2138221E1D94725B00C1FEEB /* JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 213822181D94725B00C1FEEB /* JSON.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -75,6 +78,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		013B78AA1FDB3231001246E1 /* IntTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = IntTests.swift; path = JSONTests/IntTests.swift; sourceTree = "<group>"; };
 		213821FA1D94723700C1FEEB /* JSON.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = JSON.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		213822031D94723700C1FEEB /* JSONTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = JSONTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		213822151D94725B00C1FEEB /* JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
@@ -205,6 +209,7 @@
 				215DB4BE1DC374B200034124 /* Blog.swift */,
 				215DB4BF1DC374B200034124 /* DateTests.swift */,
 				215DB4C01DC374B200034124 /* DeserializationTests.swift */,
+				013B78AA1FDB3231001246E1 /* IntTests.swift */,
 				215DB4C11DC374B200034124 /* Post.swift */,
 				215DB4C21DC374B200034124 /* URLTests.swift */,
 				215DB4C31DC374B200034124 /* User.swift */,
@@ -509,6 +514,7 @@
 			files = (
 				215DB4CC1DC3752400034124 /* DeserializationTests.swift in Sources */,
 				215DB4CA1DC3752400034124 /* Blog.swift in Sources */,
+				013B78AB1FDB3231001246E1 /* IntTests.swift in Sources */,
 				215DB4CF1DC3752400034124 /* User.swift in Sources */,
 				215DB4CE1DC3752400034124 /* URLTests.swift in Sources */,
 				215DB4CB1DC3752400034124 /* DateTests.swift in Sources */,
@@ -544,6 +550,7 @@
 			files = (
 				215DB4D81DC3752600034124 /* DeserializationTests.swift in Sources */,
 				215DB4D61DC3752600034124 /* Blog.swift in Sources */,
+				013B78AD1FDB3231001246E1 /* IntTests.swift in Sources */,
 				215DB4DB1DC3752600034124 /* User.swift in Sources */,
 				215DB4DA1DC3752600034124 /* URLTests.swift in Sources */,
 				215DB4D71DC3752600034124 /* DateTests.swift in Sources */,
@@ -568,6 +575,7 @@
 			files = (
 				215DB4D21DC3752500034124 /* DeserializationTests.swift in Sources */,
 				215DB4D01DC3752500034124 /* Blog.swift in Sources */,
+				013B78AC1FDB3231001246E1 /* IntTests.swift in Sources */,
 				215DB4D51DC3752500034124 /* User.swift in Sources */,
 				215DB4D41DC3752500034124 /* URLTests.swift in Sources */,
 				215DB4D11DC3752500034124 /* DateTests.swift in Sources */,

--- a/Tests/JSONTests/IntTests.swift
+++ b/Tests/JSONTests/IntTests.swift
@@ -1,0 +1,45 @@
+//
+//  IntTests.swift
+//  JSON
+//
+
+import XCTest
+import JSON
+
+struct IntModel: Equatable {
+	let id: Int64
+}
+
+extension IntModel: JSONDeserializable {
+	init(jsonRepresentation dictionary: JSONDictionary) throws {
+		id = try decode(dictionary, key: "id")
+	}
+}
+
+func ==(lhs: IntModel, rhs: IntModel) -> Bool {
+	return lhs.id == rhs.id
+}
+
+final class IntTests: XCTestCase {
+	
+	
+	func testDeserializeDictionary() throws {
+		let expected = IntModel(id: 1234)
+		let dictionary: JSONDictionary = [
+			"id": 1234
+		]
+		
+		XCTAssertEqual(expected, try decode(dictionary))
+	}
+	
+	func testDeserializeData() throws {
+		let expected = IntModel(id: 1234)
+		
+		let data = "{\"id\": 1234}".data(using: .utf8)!
+		
+		let json = try JSONSerialization.jsonObject(with: data, options: []) as! JSONDictionary
+		
+		XCTAssertEqual(expected, try decode(json))
+	}
+	
+}


### PR DESCRIPTION
Any idea why this fails to decode?

I guess I figured it out. The number in the `JSONSerialization` is a NSNumber where the other is a swift `Int` and can't cast to `Int64`. Not sure how to fix this though